### PR TITLE
Update Plezi link + features

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -579,14 +579,15 @@ tableRef.on("delete", function(item) {
 * EventSource
 * Ruby
 
-### [Plezi](https://github.com/boazsegev/plezi)
+### [Plezi](http://www.plezi.io)
 
 > Plezi is an easy to use Ruby Websocket Framework, with full RESTful routing support and HTTP streaming support. It's name comes from the word "fun" in Haitian, since Plezi is really fun to work with and it keeps our code clean and streamlined.
 
 * WebSockets
-* Long Pulling (supports RESTful HTTP routes)
+* Long Polling (supports RESTful HTTP routes)
 * HTTP Streaming
 * Ruby
+* Rails/Sinatra/Rack integration
 
 ### [phpDaemon](http://daemon.io/)
 


### PR DESCRIPTION
This updates the Plezi framework's website link (the official website), fixes a typo in the features and adds information about Rails/Sinatra/Rack integration.